### PR TITLE
fix: Rename INDEX.md to index.md for proper MkDocs homepage routing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -109,4 +109,4 @@ ArticDBM is released under the [AGPL-3.0 License](LICENSE.md), ensuring it remai
 
 ---
 
-**Ready to get started?** Check out our [Usage Guide](USAGE.md) or jump straight into the [Quick Start](#-quick-start) above!
+**Ready to get started?** Check out our [Usage Guide](USAGE.md) or jump straight into the [Quick Start](#quick-start) above!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,7 @@ plugins:
       minify_html: true
 
 nav:
-  - Home: INDEX.md
+  - Home: index.md
   - Getting Started:
     - Usage Guide: USAGE.md
   - Architecture:


### PR DESCRIPTION
- MkDocs expects lowercase index.md as the default homepage file
- Update mkdocs.yml navigation to reference index.md instead of INDEX.md
- Fix internal anchor link format in index.md
- This resolves the 404 error at docs.articdbm.penguintech.io/

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Lowercase the default MkDocs homepage filename, update the configuration to match, and fix internal anchor links to restore proper routing.

Bug Fixes:
- Rename documentation homepage file to 'index.md' and update mkdocs.yml to resolve 404 error

Enhancements:
- Correct internal anchor link format in index.md

Documentation:
- Update mkdocs.yml navigation to reference lowercase index.md