### PR TITLE
website patch

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -582,8 +582,8 @@ mysql -h localhost -P 3306 -u user -p</code></pre>
                             <p>Each managed database connection in your ArticDBM configuration counts as one database, regardless of size or usage.</p>
                         </div>
                         <div class="faq-item">
-                            <h4>Can I mix Community and Enterprise?</h4>
-                            <p>Yes! You can upgrade individual databases to Enterprise features while keeping others on Community edition.</p>
+                            <h4>Can I upgrade to Enterprise later?</h4>
+                            <p>Yes! You can upgrade your entire ArticDBM instance to Enterprise to unlock advanced features for all your databases.</p>
                         </div>
                         <div class="faq-item">
                             <h4>Do you offer volume discounts?</h4>

--- a/website/style.css
+++ b/website/style.css
@@ -1587,7 +1587,7 @@ body {
 }
 
 .pricing-faq h3 {
-    color: white;
+    color: var(--deep-blue);
     text-align: center;
     font-size: 2rem;
     margin-bottom: 2rem;


### PR DESCRIPTION
misleading claim fix

## Summary by Sourcery

Clarify the Enterprise upgrade process in the website FAQ to remove the misleading claim about mixing editions.

Documentation:
- Update FAQ question to “Can I upgrade to Enterprise later?” instead of asking about mixing editions.
- Revise FAQ answer to state that upgrading to Enterprise applies to the entire ArticDBM instance.